### PR TITLE
Replace deprecated `request` lib and store HTTP status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-javascript-template:1.3.5
+FROM semtech/mu-javascript-template:1.4.0
 LABEL maintainer=info@redpencil.io
 
 RUN mkdir -p /share

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ import { getRemoteDataObjectByStatus,
          updateDownloadEvent,
          createPhysicalFileDataObject,
          updateDownloadEventOnSuccess,
+         saveHttpStatusCode,
          READY,
          ONGOING,
          SUCCESS,
@@ -172,6 +173,7 @@ async function downloadFile(remoteObject, headers) {
 
     try {
       let response = await fetch(requestBody.url, { headers: requestBody.headers });
+      await saveHttpStatusCode(remoteObject.subject.value, response.status);
       if (response.ok) { // res.status >= 200 && res.status < 300
         //--- Status: OK
         //--- create file attributes
@@ -197,7 +199,6 @@ async function downloadFile(remoteObject, headers) {
           cleanUpFile(localAddress);
           return { resource: remoteObject, error: err };
         }
-
       } else {
         //--- NO OK
         return {

--- a/app.js
+++ b/app.js
@@ -171,7 +171,7 @@ async function downloadFile(remoteObject, headers) {
 
     try {
       let response = await fetch(requestBody.url, { headers: requestBody.headers });
-      await saveHttpStatusCode(url, response.status);
+      await saveHttpStatusCode(remoteObject.subject.value, response.status);
       if (response.ok) { // res.status >= 200 && res.status < 300
         //--- Status: OK
         //--- create file attributes
@@ -206,7 +206,7 @@ async function downloadFile(remoteObject, headers) {
       console.error(`  remote resource: ${remoteObject.subject.value}`);
       console.error(`  remote url: ${url}`);
       console.error(`  error: ${err}`);
-      await saveCacheError(url, err);
+      await saveCacheError(remoteObject.subject.value, err);
       throw err;
     }
 }

--- a/app.js
+++ b/app.js
@@ -178,7 +178,7 @@ async function downloadFile(remoteObject, headers) {
         let bareName = uuid();
         let physicalFileName = [bareName, extension].join('');
         let localAddress = path.join(FILE_STORAGE, physicalFileName);
-      
+
         //--- write the file
         try {
           response.body.pipe(fs.createWriteStream(localAddress));

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ import { getRemoteDataObjectByStatus,
          createPhysicalFileDataObject,
          updateDownloadEventOnSuccess,
          saveHttpStatusCode,
+         saveCacheError,
          READY,
          ONGOING,
          SUCCESS,
@@ -170,7 +171,7 @@ async function downloadFile(remoteObject, headers) {
 
     try {
       let response = await fetch(requestBody.url, { headers: requestBody.headers });
-      await saveHttpStatusCode(remoteObject.subject.value, response.status);
+      await saveHttpStatusCode(url, response.status);
       if (response.ok) { // res.status >= 200 && res.status < 300
         //--- Status: OK
         //--- create file attributes
@@ -205,6 +206,7 @@ async function downloadFile(remoteObject, headers) {
       console.error(`  remote resource: ${remoteObject.subject.value}`);
       console.error(`  remote url: ${url}`);
       console.error(`  error: ${err}`);
+      await saveCacheError(url, err);
       throw err;
     }
 }
@@ -244,6 +246,7 @@ async function associateCachedFile(downloadResult, remoteDataObjectQueryResult) 
     console.error(err);
     console.error(`  downloaded file: ${downloadResult.cachedFileAddress}`);
     console.error(`  FileAddress object: ${uri}`);
+    await saveCacheError(uri, err);
     throw err;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-url-service",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Microservice downloading a local copy of a remote file by URL",
   "main": "app.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",
     "fs-extra": "^8.1.0",
-    "request": "^2.88.0",
     "lodash.flatten": "^4.4.0",
     "lodash.uniq": "^4.5.0",
     "mime-types": "^2.1.24",
+    "node-fetch": "^2.6.1",
     "ssl-root-cas": "^1.3.1"
   },
   "devDependencies": {},

--- a/queries.js
+++ b/queries.js
@@ -256,6 +256,28 @@ async function saveHttpStatusCode(remoteUrl, statusCode){
   `;
   await query(q);
 }
+
+async function saveCacheError(remoteUrl, error){
+  let q = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    DELETE {
+      GRAPH ?g {
+
+        ?url ext:cacheError ?error.
+      }
+    }
+    INSERT {
+      GRAPH ?g {
+        ?url ext:cacheError ${sparqlEscapeString(error.toString())}.
+      }
+    }
+    WHERE {
+      BIND(${sparqlEscapeUri(remoteUrl)} as ?url)
+      BIND(${sparqlEscapeUri(DEFAULT_GRAPH)} as ?g)
+
+      GRAPH ?g {
+        ?url ext:cacheError ?code.
       }
     }
   `;
@@ -271,6 +293,7 @@ export { getRemoteDataObjectByStatus,
          createPhysicalFileDataObject,
          updateDownloadEventOnSuccess,
          saveHttpStatusCode,
+         saveCacheError,
          READY,
          ONGOING,
          SUCCESS,

--- a/queries.js
+++ b/queries.js
@@ -231,6 +231,19 @@ async function createPhysicalFileDataObject(fileObjectUri, dataSourceUri, name, 
   return await query( q );
 };
 
+async function saveHttpStatusCode(remoteUrl, statusCode){
+  let q = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(DEFAULT_GRAPH)} {
+        ${sparqlEscapeUri(remoteUrl)} ext:httpStatusCode ${sparqlEscapeInt(statusCode)}.
+      }
+    }
+  `;
+  await query(q);
+}
+
 export { getRemoteDataObjectByStatus,
          getRequestHeadersForRemoteDataObject,
          updateStatus,
@@ -239,6 +252,7 @@ export { getRemoteDataObjectByStatus,
          updateDownloadEvent,
          createPhysicalFileDataObject,
          updateDownloadEventOnSuccess,
+         saveHttpStatusCode,
          READY,
          ONGOING,
          SUCCESS,

--- a/queries.js
+++ b/queries.js
@@ -235,9 +235,27 @@ async function saveHttpStatusCode(remoteUrl, statusCode){
   let q = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
-    INSERT DATA {
-      GRAPH ${sparqlEscapeUri(DEFAULT_GRAPH)} {
-        ${sparqlEscapeUri(remoteUrl)} ext:httpStatusCode ${sparqlEscapeInt(statusCode)}.
+    DELETE {
+      GRAPH ?g {
+        ?url ext:httpStatusCode ?code.
+      }
+    }
+    INSERT {
+      GRAPH ?g {
+        ?url ext:httpStatusCode ${sparqlEscapeInt(statusCode)}.
+      }
+    }
+    WHERE {
+      BIND(${sparqlEscapeUri(remoteUrl)} as ?url)
+      BIND(${sparqlEscapeUri(DEFAULT_GRAPH)} as ?g)
+
+      GRAPH ?g {
+        ?url ext:httpStatusCode ?code.
+      }
+    }
+  `;
+  await query(q);
+}
       }
     }
   `;

--- a/queries.js
+++ b/queries.js
@@ -240,17 +240,18 @@ async function saveHttpStatusCode(remoteUrl, statusCode){
         ?url ext:httpStatusCode ?code.
       }
     }
-    INSERT {
-      GRAPH ?g {
-        ?url ext:httpStatusCode ${sparqlEscapeInt(statusCode)}.
-      }
-    }
     WHERE {
       BIND(${sparqlEscapeUri(remoteUrl)} as ?url)
       BIND(${sparqlEscapeUri(DEFAULT_GRAPH)} as ?g)
 
       GRAPH ?g {
         ?url ext:httpStatusCode ?code.
+      }
+    }
+    ;
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(DEFAULT_GRAPH)} {
+        ${sparqlEscapeUri(remoteUrl)} ext:httpStatusCode ${sparqlEscapeInt(statusCode)}.
       }
     }
   `;
@@ -267,17 +268,18 @@ async function saveCacheError(remoteUrl, error){
         ?url ext:cacheError ?error.
       }
     }
-    INSERT {
-      GRAPH ?g {
-        ?url ext:cacheError ${sparqlEscapeString(error.toString())}.
-      }
-    }
     WHERE {
       BIND(${sparqlEscapeUri(remoteUrl)} as ?url)
       BIND(${sparqlEscapeUri(DEFAULT_GRAPH)} as ?g)
 
       GRAPH ?g {
         ?url ext:cacheError ?code.
+      }
+    }
+    ;
+    INSERT {
+      GRAPH ${sparqlEscapeUri(DEFAULT_GRAPH)} {
+        ${sparqlEscapeUri(remoteUrl)} ext:cacheError ${sparqlEscapeString(error.toString())}.
       }
     }
   `;

--- a/queries.js
+++ b/queries.js
@@ -277,7 +277,7 @@ async function saveCacheError(remoteUrl, error){
       }
     }
     ;
-    INSERT {
+    INSERT DATA {
       GRAPH ${sparqlEscapeUri(DEFAULT_GRAPH)} {
         ${sparqlEscapeUri(remoteUrl)} ext:cacheError ${sparqlEscapeString(error.toString())}.
       }


### PR DESCRIPTION
This PR brings two changes:
- replace `request` by `node-fetch` as it was deprecated and causing issues
- store the HTTP status of the requests to make the debug smoother in the future

Note: I'm a bit unsure of the `ext:httpStatusCode` predicate, this can be modified / discussed :)