### PR TITLE
Correct to the model of the file-service

### DIFF
--- a/app.js
+++ b/app.js
@@ -210,9 +210,8 @@ async function downloadFile(remoteObject, headers, credentialsType, fileExtensio
   const url = remoteObject.url.value;
 
   const requestBody = {url};
-  if (Object.keys(headers).length > 0) {
-    requestBody.options = {headers};
-  }
+  headers = headers || {};
+  requestBody.options = { headers };
 
   if (credentialsType == BASIC_AUTH) {
     const credentialsInfo = await getBasicCredentialsForRemoteDataObject(remoteObject.subject);
@@ -242,6 +241,7 @@ async function downloadFile(remoteObject, headers, credentialsType, fileExtensio
 
     requestBody.options = tokenResponse.sign({
       method: 'GET',
+      headers,
       url: requestBody.url
     });
   }

--- a/queries.js
+++ b/queries.js
@@ -286,7 +286,7 @@ async function createPhysicalFileDataObject(fileObjectUri, dataSourceUri, name, 
               dct:format ${sparqlEscapeString(type)};
               nfo:fileSize ${sparqlEscapeInt(fileSize)};
               dbpedia:fileExtension ${sparqlEscapeString(extension)};
-              nfo:fileCreated ${sparqlEscapeDate(created)}.
+              dct:created ${sparqlEscapeDate(created)}.
       }
     }
     WHERE {

--- a/queries.js
+++ b/queries.js
@@ -54,9 +54,9 @@ async function getRequestHeadersForRemoteDataObject(subject) {
     PREFIX rpioHttp: <http://redpencil.data.gift/vocabularies/http/>
 
     SELECT DISTINCT ?header ?headerValue ?headerName WHERE {
-       ${sparqlEscapeUri(subject.value)} rpioHttp:requestHeader ?header.
-       ?header http:fieldValue ?headerValue.
-       ?header http:fieldName ?headerName.
+      ${sparqlEscapeUri(subject.value)} rpioHttp:requestHeader ?header.
+      ?header http:fieldValue ?headerValue.
+      ?header http:fieldName ?headerName.
     }
   `;
   await query(q);


### PR DESCRIPTION
Due to a documentation issue, the correct property to indicate the creation date of the file is with `dct:created` and not `nfo:fileCreated`. This PR contains this simple fix, but beware, this might have large implications when used in stacks with divergent file models.