### PR TITLE
Fix attachments with authentication not working

### DIFF
--- a/app.js
+++ b/app.js
@@ -210,9 +210,8 @@ async function downloadFile(remoteObject, headers, credentialsType, fileExtensio
   const url = remoteObject.url.value;
 
   const requestBody = {url};
-  if (Object.keys(headers).length > 0) {
-    requestBody.options = {headers};
-  }
+  headers = headers || {};
+  requestBody.options = { headers };
 
   if (credentialsType == BASIC_AUTH) {
     const credentialsInfo = await getBasicCredentialsForRemoteDataObject(remoteObject.subject);
@@ -242,6 +241,7 @@ async function downloadFile(remoteObject, headers, credentialsType, fileExtensio
 
     requestBody.options = tokenResponse.sign({
       method: 'GET',
+      headers,
       url: requestBody.url
     });
   }

--- a/queries.js
+++ b/queries.js
@@ -54,9 +54,9 @@ async function getRequestHeadersForRemoteDataObject(subject) {
     PREFIX rpioHttp: <http://redpencil.data.gift/vocabularies/http/>
 
     SELECT DISTINCT ?header ?headerValue ?headerName WHERE {
-       ${sparqlEscapeUri(subject.value)} rpioHttp:requestHeader ?header.
-       ?header http:fieldValue ?headerValue.
-       ?header http:fieldName ?headerName.
+      ${sparqlEscapeUri(subject.value)} rpioHttp:requestHeader ?header.
+      ?header http:fieldValue ?headerValue.
+      ?header http:fieldName ?headerName.
     }
   `;
   await query(q);


### PR DESCRIPTION
This PR is a bit sad. I didn't realise @cecemel already fixed the issue with not working attachments when also using authentication and I spent way to much time trying to figure this out. The issue was twofold however, and this PR also includes a cleaner way of setting the options for the fetch request (see [app.js:213](https://github.com/lblod/download-url-service/blob/ce62fa47e35667d3c7afd367a3063115a2855ced/app.js#L213)), which would also have fixed the issue. At the same time, I would suggest also including the headers when using OAUTH2 (see [app.js:244](https://github.com/lblod/download-url-service/blob/ce62fa47e35667d3c7afd367a3063115a2855ced/app.js#L244)).