### PR TITLE
Checking if authType matches the credentialsType

### DIFF
--- a/queries.js
+++ b/queries.js
@@ -75,9 +75,17 @@ async function getCredentialsTypeForRemoteDataObject(subject) {
         ?authenticationConf dgftSec:securityConfiguration/rdf:type ?securityConfigurationType .
     }
   `;
-  await query(q);
   const result = await query(q);
-  return result.results.bindings[0] ? result.results.bindings[0].securityConfigurationType.value : null;
+  const { bindings } = result.results;
+  let credentialsType = null;
+  for (const binding of bindings) {
+    const value = binding.securityConfigurationType.value;
+    if (value.includes(BASIC_AUTH) || value.includes(OAUTH2)) {
+      credentialsType = value;
+      break;
+    }
+  }
+  return credentialsType;
 };
 
 async function getBasicCredentialsForRemoteDataObject(subject) {

--- a/queries.js
+++ b/queries.js
@@ -73,19 +73,15 @@ async function getCredentialsTypeForRemoteDataObject(subject) {
     SELECT DISTINCT ?securityConfigurationType WHERE {
         ${sparqlEscapeUri(subject.value)} dgftSec:targetAuthenticationConfiguration ?authenticationConf .
         ?authenticationConf dgftSec:securityConfiguration/rdf:type ?securityConfigurationType .
+        VALUES ?securityConfigurationType {
+          <https://www.w3.org/2019/wot/security#BasicSecurityScheme>
+          <https://www.w3.org/2019/wot/security#OAuth2SecurityScheme>
+      }
     }
+    
   `;
   const result = await query(q);
-  const { bindings } = result.results;
-  let credentialsType = null;
-  for (const binding of bindings) {
-    const value = binding.securityConfigurationType.value;
-    if (value.includes(BASIC_AUTH) || value.includes(OAUTH2)) {
-      credentialsType = value;
-      break;
-    }
-  }
-  return credentialsType;
+  return result.results.bindings[0] ? result.results.bindings[0].securityConfigurationType.value : null;
 };
 
 async function getBasicCredentialsForRemoteDataObject(subject) {


### PR DESCRIPTION
This adds an extra check for the auth configuration type.

When we query the type from the remoteDataObject we get for basic auth
```
<https://www.w3.org/2019/wot/security#SecurityScheme>
<https://www.w3.org/2019/wot/security#BasicSecurityScheme>
```

But for the remoteDataObject of type oauth2 we get this
```
<https://www.w3.org/2019/wot/security#OAuth2SecurityScheme>
<https://www.w3.org/2019/wot/security#SecurityScheme>
```

The order is not guaranteed, so this check is eliminating the risk of errors.