### PR TITLE
[Harvesting multi-pages with auth] Removing deleteCredential in performDownloadTask

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,7 +127,6 @@ async function performDownloadTask(remoteObject, downloadEventUri) {
     return acc;
   }, {});
 
-  const credentialsType = await getCredentialsTypeForRemoteDataObject(remoteObject.subject);
 
   // Downloading the file as a temporary file
   let tmpDownloadResult = await downloadFile(remoteObject, requestHeaders, credentialsType, '.tmp');
@@ -136,10 +135,6 @@ async function performDownloadTask(remoteObject, downloadEventUri) {
   // Store the final file in the store
   let physicalFileUri = await associateCachedFile(downloadResult, remoteObject);
 
-  //TODO: this needs re-thinking
-  if(REMOVE_AUTHENTICATION_SECRETS_AFTER_DOWLOAD){
-    await deleteCredentials(remoteObject, credentialsType);
-  }
 
   await updateDownloadEventOnSuccess(downloadEventUri, physicalFileUri);
 


### PR DESCRIPTION
DL-4860

This PR is responsible of making the harvesting for multiple pages with authentication working.

This is linked to other PRs in `harvest-collector-service` : https://github.com/lblod/harvest-collector-service/pull/13 and `harvesting-import-service` : https://github.com/lblod/harvesting-import-service/pull/4, so to test it make sure you have them in your docker override file.
