### PR TITLE
Add extra heuristic to guess a filename

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,7 +236,7 @@ async function downloadFile(remoteObject, headers, credentialsType) {
       const uuidName = uuid();
 
       let fileName;
-      const fileNameExt = tryGetFilename(response, remoteObject);
+      const fileNameExt = tryGetFilenameWithExtension(response, remoteObject);
       let extensionFromFileName = path.extname(fileNameExt || '');
       if (extensionFromFileName !== ''
           && extensionFromFileName !== '.'
@@ -368,7 +368,7 @@ function getExtensionFrom(headers) {
  * @returns {String | undefined} Filename with extension, or last part of the
  * path in the URL. Returns undefined when URL path is undefined.
  */
-function tryGetFilename(response, remoteObject) {
+function tryGetFilenameWithExtension(response, remoteObject) {
   const headerCD = response.headers.get('Content-Disposition');
   if (headerCD) {
     const disposition = contentDisposition.parse(headerCD);

--- a/app.js
+++ b/app.js
@@ -390,6 +390,10 @@ function tryGetFilename(response, remoteObject) {
   if (filename3) return filename3;
 
   // Try the suggested filename from the remote data object (if available)
+  // This suggestion is assumed to come from another step; which likely
+  //  applied a heuristic to suggest a filename. (e.g. import-submission-service)
+  // We leave the remote host in charge; but if nothing else is provided
+  // we take this.
   if (remoteObject.suggestedFilename?.value) {
     return remoteObject.suggestedFilename.value;
   }

--- a/app.js
+++ b/app.js
@@ -236,7 +236,7 @@ async function downloadFile(remoteObject, headers, credentialsType) {
       const uuidName = uuid();
 
       let fileName;
-      const fileNameExt = tryGetFilenameWithExtension(response);
+      const fileNameExt = tryGetFilename(response, remoteObject);
       let extensionFromFileName = path.extname(fileNameExt || '');
       if (extensionFromFileName !== ''
           && extensionFromFileName !== '.'
@@ -359,14 +359,16 @@ function getExtensionFrom(headers) {
  * Try to get the full filename from the HTTP response, with extension
  * included. This tries multiple mechanisms in order: get the filename from the
  * HTTP header 'Content-Disposition', get the filename from URL parameters
- * (guesswork), or get the filename from the path in the URL.
+ * (guesswork), get a suggested filename from the remote data object, or get
+ * the filename from the path in the URL.
  *
  * @function
  * @param {HTTP Response} response - Response object from the HTTP request.
+ * @param {Object} remoteObject - Remote data object query result.
  * @returns {String | undefined} Filename with extension, or last part of the
  * path in the URL. Returns undefined when URL path is undefined.
  */
-function tryGetFilenameWithExtension(response) {
+function tryGetFilename(response, remoteObject) {
   const headerCD = response.headers.get('Content-Disposition');
   if (headerCD) {
     const disposition = contentDisposition.parse(headerCD);
@@ -386,6 +388,11 @@ function tryGetFilenameWithExtension(response) {
   if (filename2) return filename2;
   const filename3 = parameters.get('name');
   if (filename3) return filename3;
+
+  // Try the suggested filename from the remote data object (if available)
+  if (remoteObject.suggestedFilename?.value) {
+    return remoteObject.suggestedFilename.value;
+  }
 
   // Last resort: return last segment of URL path
   const urlPath = url.pathname || '';

--- a/queries.js
+++ b/queries.js
@@ -31,7 +31,7 @@ async function getRemoteDataObjectByStatus(status, uris = []) {
     PREFIX    nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
     PREFIX    nuao: <http://www.semanticdesktop.org/ontologies/2010/01/25/nuao#>
 
-    SELECT DISTINCT ?subject ?url ?uuid ?downloadEventUri
+    SELECT DISTINCT ?subject ?url ?uuid ?downloadEventUri ?suggestedFilename
     WHERE {
       GRAPH ?g {
         ?subject a nfo:RemoteDataObject .
@@ -39,6 +39,7 @@ async function getRemoteDataObjectByStatus(status, uris = []) {
         ?subject mu:uuid ?uuid;
                  nie:url ?url;
                  adms:status ${sparqlEscapeUri(status)}.
+        OPTIONAL { ?subject <http://mu.semte.ch/vocabularies/ext/suggestedFilename> ?suggestedFilename. }
       }
       OPTIONAL { ?downloadEventUri nuao:involves ?subject }
     }


### PR DESCRIPTION
We added a heuristic to guess a filename. This extra heuristic tries to get the suggested filename attached to the remote data object. It is used when available, in case the remote host does not provide a proper filename. The remote host remains the authority.

The suggested filename attached to the remote data object comes from another service, which likely applied its own heuristic to determine it.

For more context on why this was needed: [DL-7047] and https://github.com/lblod/import-submission-service/pull/13
